### PR TITLE
Remove Null Characters from Strings

### DIFF
--- a/target_postgres/sinks.py
+++ b/target_postgres/sinks.py
@@ -281,6 +281,12 @@ class postgresSink(SQLSink):
         for key, value in record.items():
             # Get the Item/Column property
             property_schema: dict = properties.get(key)
+            # PostgreSQL does not filter out Null characters
+            # presence of these characters will cause
+            # the target to fail out
+            if isinstance(value, str) and '\x00' in value:
+                record.update({key: value.replace('\x00', '')})
+                self.logger.info("Removed Null Character(s) From a Record")
             # Decode base64 binary fields in record
             if property_schema.get('contentEncoding') == 'base64':
                 # We need to change from hex first becuase in


### PR DESCRIPTION
An if statement looking for Null characters in string values that triggers code to replace them with blanks and log that a Null has been removed was added to the `postgresSink.preprocess_record` method

Closes #9