### PR TITLE
feat: Dynamic batch sizing

### DIFF
--- a/target_postgres/sinks.py
+++ b/target_postgres/sinks.py
@@ -293,6 +293,8 @@ class postgresSink(SQLSink):
         Returns:
             A new, processed record.
         """
+        # Starting line for max_size perf counter
+        self.set_start_time
         # Get the Stream Properties Dictornary from the Schema
         properties: dict = self.schema.get('properties')
 

--- a/target_postgres/sinks.py
+++ b/target_postgres/sinks.py
@@ -260,9 +260,12 @@ class postgresSink(SQLSink):
 
     def counter_based_max_size(self):
         perf_diff = self.MAX_SIZE_MAX_PERF_COUNTER - self.max_size_perf_counter
+        self.logger.info(f"The pref_diff is: {perf_diff}")
 
         if perf_diff < 0:
             self.MAX_SIZE_DEFAULT = self.max_size - 10
+        elif perf_diff >= 0.75:
+            self.MAX_SIZE_DEFAULT = self.max_size + 10
 
     def conform_name(self, name: str, object_type: Optional[str] = None) -> str:
         """Conform a stream property name to one suitable for the target system.

--- a/target_postgres/sinks.py
+++ b/target_postgres/sinks.py
@@ -238,6 +238,11 @@ class postgresSink(SQLSink):
 
     connector_class = postgresConnector
 
+    MAX_SIZE_DEFAULT = 100
+    MAX_SIZE_MAX_PERF_COUNTER = 1
+    MAX_SIZE_START_TIME: float = None
+    MAX_SIZE_STOP_TIME: float = None
+
     def conform_name(self, name: str, object_type: Optional[str] = None) -> str:
         """Conform a stream property name to one suitable for the target system.
 

--- a/target_postgres/sinks.py
+++ b/target_postgres/sinks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from base64 import b64decode
 from typing import Any, Dict, cast, Iterable, Iterator, Optional
 from contextlib import contextmanager
+import time
 
 import sqlalchemy
 from sqlalchemy import Table, MetaData, exc, types, engine_from_config

--- a/target_postgres/sinks.py
+++ b/target_postgres/sinks.py
@@ -264,8 +264,12 @@ class postgresSink(SQLSink):
 
         if perf_diff < 0:
             self.MAX_SIZE_DEFAULT = self.max_size - 10
+        if perf_diff >= 0.3 and perf_diff < 0.5:
+            self.MAX_SIZE_DEFAULT = self.max_size + 100
+        elif perf_diff >= 0.5 and perf_diff < 0.75:
+            self.MAX_SIZE_DEFAULT = self.max_size + 1000
         elif perf_diff >= 0.75:
-            self.MAX_SIZE_DEFAULT = self.max_size + 10
+            self.MAX_SIZE_DEFAULT = self.max_size + 10000
 
     def conform_name(self, name: str, object_type: Optional[str] = None) -> str:
         """Conform a stream property name to one suitable for the target system.

--- a/target_postgres/sinks.py
+++ b/target_postgres/sinks.py
@@ -262,7 +262,8 @@ class postgresSink(SQLSink):
         return perf_counter
 
     def counter_based_max_size(self):
-        perf_diff = self.MAX_SIZE_MAX_PERF_COUNTER - self.max_size_perf_counter
+        max_perf_counter = self.MAX_SIZE_MAX_PERF_COUNTER
+        perf_diff = max_perf_counter - self.max_size_perf_counter
         # logger for testing remove later start
         # self.logger.info(f"The MAX_SIZE_START_TIME {self.MAX_SIZE_START_TIME}")
         # self.logger.info(f"The MAX_SIZE_STOP_TIME {self.MAX_SIZE_STOP_TIME}")
@@ -270,14 +271,14 @@ class postgresSink(SQLSink):
         # self.logger.info(f"MAX_SIZE_DEFAULT: {self.max_size}")
         # self.logger.info(f"The pref_diff is: {perf_diff}")
         # logger for testing remove later ended
-        if perf_diff < -0.2:
+        if perf_diff < -1.0*(max_perf_counter * 0.25):
             if self.max_size >= 10000:
                 self.MAX_SIZE_DEFAULT = self.max_size - 1000
             elif self.max_size >= 1000:
                 self.MAX_SIZE_DEFAULT = self.max_size - 100
             elif self.max_size > 10:
                 self.MAX_SIZE_DEFAULT = self.max_size - 10
-        if perf_diff >= 0.3 and self.max_size < 10000:
+        if perf_diff >= (max_perf_counter * 0.33) and self.max_size < 10000:
             # if self.max_size >= 10000:
             #     self.MAX_SIZE_DEFAULT = self.max_size + 10000
             if self.max_size >= 1000:

--- a/target_postgres/sinks.py
+++ b/target_postgres/sinks.py
@@ -367,6 +367,13 @@ class postgresSink(SQLSink):
 
         # Finish Line for max_size perf counter
         self.set_stop_time
+
+        # logger for testing remove later start
+        self.logger.info(f"The MAX_SIZE_START_TIME {self.MAX_SIZE_START_TIME}")
+        self.logger.info(f"The MAX_SIZE_STOP_TIME {self.MAX_SIZE_STOP_TIME}")
+        self.logger.info(f"This was the total elapsed time: {self.max_size_perf_counter:0.2f} seconds")
+        self.logger.info(f"MAX_SIZE_DEFAULT: {self.max_size}")
+        # logger end
         
         if isinstance(records, list):
             return len(records)  # If list, we can quickly return record count.

--- a/target_postgres/sinks.py
+++ b/target_postgres/sinks.py
@@ -243,6 +243,21 @@ class postgresSink(SQLSink):
     MAX_SIZE_START_TIME: float = None
     MAX_SIZE_STOP_TIME: float = None
 
+    @property
+    def set_start_time(self):
+        self.MAX_SIZE_START_TIME = time.perf_counter()
+
+    @property
+    def set_stop_time(self):
+        self.MAX_SIZE_STOP_TIME = time.perf_counter()
+
+    @property
+    def max_size_perf_counter(self) -> float:
+        if self.MAX_SIZE_STOP_TIME and self.MAX_SIZE_START_TIME:
+            perf_counter: float = self.MAX_SIZE_STOP_TIME - self.MAX_SIZE_START_TIME
+
+        return perf_counter
+
     def conform_name(self, name: str, object_type: Optional[str] = None) -> str:
         """Conform a stream property name to one suitable for the target system.
 

--- a/target_postgres/sinks.py
+++ b/target_postgres/sinks.py
@@ -365,6 +365,9 @@ class postgresSink(SQLSink):
             error = str(e.__dict__['orig'])
             self.logger.info(error)
 
+        # Finish Line for max_size perf counter
+        self.set_stop_time
+        
         if isinstance(records, list):
             return len(records)  # If list, we can quickly return record count.
 

--- a/target_postgres/sinks.py
+++ b/target_postgres/sinks.py
@@ -258,6 +258,12 @@ class postgresSink(SQLSink):
 
         return perf_counter
 
+    def counter_based_max_size(self):
+        perf_diff = self.MAX_SIZE_MAX_PERF_COUNTER - self.max_size_perf_counter
+
+        if perf_diff < 0:
+            self.MAX_SIZE_DEFAULT = self.max_size - 10
+
     def conform_name(self, name: str, object_type: Optional[str] = None) -> str:
         """Conform a stream property name to one suitable for the target system.
 
@@ -373,8 +379,10 @@ class postgresSink(SQLSink):
         self.logger.info(f"The MAX_SIZE_STOP_TIME {self.MAX_SIZE_STOP_TIME}")
         self.logger.info(f"This was the total elapsed time: {self.max_size_perf_counter:0.2f} seconds")
         self.logger.info(f"MAX_SIZE_DEFAULT: {self.max_size}")
-        # logger end
-        
+        self.counter_based_max_size()
+        self.logger.info(f"MAX_SIZE_DEFAULT: {self.max_size}")
+        # logger for testing remove later ended
+
         if isinstance(records, list):
             return len(records)  # If list, we can quickly return record count.
 

--- a/target_postgres/sinks.py
+++ b/target_postgres/sinks.py
@@ -264,11 +264,13 @@ class postgresSink(SQLSink):
 
         if perf_diff < 0:
             self.MAX_SIZE_DEFAULT = self.max_size - 10
-        if perf_diff >= 0.3 and perf_diff < 0.5:
+        if perf_diff >= 0.2 and self.max_size >= 10:
+            self.MAX_SIZE_DEFAULT = self.max_size + 10
+        if perf_diff >= 0.3 and perf_diff < 0.5 and self.max_size >= 100:
             self.MAX_SIZE_DEFAULT = self.max_size + 100
-        elif perf_diff >= 0.5 and perf_diff < 0.75:
-            self.MAX_SIZE_DEFAULT = self.max_size + 1000
-        elif perf_diff >= 0.75:
+        elif perf_diff >= 0.5 and perf_diff < 0.75 and self.max_size >= 1000:
+            self.MAX_SIZE_DEFAULT = self.max_size + 5000
+        elif perf_diff >= 0.75 and self.max_size >= 5000:
             self.MAX_SIZE_DEFAULT = self.max_size + 10000
 
     def conform_name(self, name: str, object_type: Optional[str] = None) -> str:

--- a/target_postgres/target.py
+++ b/target_postgres/target.py
@@ -13,6 +13,8 @@ from target_postgres.sinks import (
 class Targetpostgres(SQLTarget):
     """Sample target for postgres."""
 
+    _MAX_RECORD_AGE_IN_MINUTES: float = 1000000.0
+
     name = "target-postgres"
     default_sink_class = postgresSink
 


### PR DESCRIPTION
This feature is a response to a workload that would not ever insert a row before the connection was timed out.  The features utilizes `time.perfcounter()` to create get a start and stop time between drain cyles.  If the cycle performes a third better than the max perf counter allowed given in seconds the batch size is increased.  If it is a quater worse then it is dreaased.

still a work in progress apt to change wildly